### PR TITLE
Merge text variant props instead of using textVariants recipe

### DIFF
--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -7,6 +7,7 @@ import {
   PolymorphicProps,
   PolymorphicRef,
 } from '~/components/Box'
+import { text } from '~/tokens/typography'
 
 import * as styles from './styles.css'
 
@@ -31,13 +32,15 @@ export const Text: PolymorphicComponent<TextProps, 'span'> = forwardRef(
       ...boxProps
     } = props
 
+    // Merge as variant as prop values so they can be overridden rather than using textVariants recipe
+    const textVariantProps = text[variant]
+
     return (
       <Box
         as={as}
         className={clsx(
           className,
           styles.textVariants({
-            variant,
             hidden,
             ellipsis,
             italic,
@@ -47,6 +50,7 @@ export const Text: PolymorphicComponent<TextProps, 'span'> = forwardRef(
           })
         )}
         ref={ref}
+        {...textVariantProps}
         {...boxProps}
       >
         {children}

--- a/src/components/Text/styles.css.ts
+++ b/src/components/Text/styles.css.ts
@@ -1,66 +1,19 @@
 import { RecipeVariants, recipe } from '@vanilla-extract/recipes'
 
 import { atoms } from '~/css'
+import { text } from '~/tokens/typography'
 
 export const textVariants = recipe({
   variants: {
     variant: {
-      inherit: atoms({
-        fontFamily: 'inherit',
-        fontSize: 'inherit',
-        lineHeight: 'inherit',
-        letterSpacing: 'inherit',
-        fontWeight: 'inherit',
-      }),
-      xlarge: atoms({
-        fontFamily: 'body',
-        fontSize: 'xlarge',
-        lineHeight: '9',
-        letterSpacing: 'none',
-        fontWeight: 'bold',
-      }),
-      large: atoms({
-        fontFamily: 'body',
-        fontSize: 'large',
-        lineHeight: '7',
-        letterSpacing: 'normal',
-        fontWeight: 'semibold',
-      }),
-      medium: atoms({
-        fontFamily: 'body',
-        fontSize: 'medium',
-        lineHeight: '6',
-        letterSpacing: 'normal',
-        fontWeight: 'bold',
-      }),
-      normal: atoms({
-        fontFamily: 'body',
-        fontSize: 'normal',
-        lineHeight: '5',
-        letterSpacing: 'wide',
-        fontWeight: 'normal',
-      }),
-      small: atoms({
-        fontFamily: 'body',
-        fontSize: 'small',
-        lineHeight: '4',
-        letterSpacing: 'wide',
-        fontWeight: 'medium',
-      }),
-      xsmall: atoms({
-        fontFamily: 'body',
-        fontSize: 'xsmall',
-        lineHeight: '4',
-        letterSpacing: 'wide',
-        fontWeight: 'bold',
-      }),
-      code: atoms({
-        fontFamily: 'mono',
-        fontSize: 'normal',
-        lineHeight: '5',
-        letterSpacing: 'none',
-        fontWeight: 'normal',
-      }),
+      inherit: atoms(text.inherit),
+      xlarge: atoms(text.xlarge),
+      large: atoms(text.large),
+      medium: atoms(text.medium),
+      normal: atoms(text.normal),
+      small: atoms(text.small),
+      xsmall: atoms(text.xsmall),
+      code: atoms(text.code),
     },
 
     /** prop overrides */

--- a/src/tokens/typography.ts
+++ b/src/tokens/typography.ts
@@ -37,3 +37,81 @@ export const lineHeights = {
   '7': '1.75rem', // 28px
   '9': '2.25rem', // 36px
 }
+
+// Text Variants: a special token which refers to typeography token keys rather than values so it can be used in the atoms function
+type TextVariant =
+  | 'inherit'
+  | 'xlarge'
+  | 'large'
+  | 'medium'
+  | 'normal'
+  | 'small'
+  | 'xsmall'
+  | 'code'
+
+interface TextVariantAtomProps {
+  fontFamily: keyof typeof fonts
+  fontSize: keyof typeof fontSizes
+  lineHeight: keyof typeof lineHeights
+  letterSpacing: keyof typeof letterSpacings
+  fontWeight: keyof typeof fontWeights
+}
+
+export const text: Record<TextVariant, TextVariantAtomProps> = {
+  inherit: {
+    fontFamily: 'inherit',
+    fontSize: 'inherit',
+    lineHeight: 'inherit',
+    letterSpacing: 'inherit',
+    fontWeight: 'inherit',
+  },
+  xlarge: {
+    fontFamily: 'body',
+    fontSize: 'xlarge',
+    lineHeight: '9',
+    letterSpacing: 'none',
+    fontWeight: 'bold',
+  },
+  large: {
+    fontFamily: 'body',
+    fontSize: 'large',
+    lineHeight: '7',
+    letterSpacing: 'normal',
+    fontWeight: 'semibold',
+  },
+  medium: {
+    fontFamily: 'body',
+    fontSize: 'medium',
+    lineHeight: '6',
+    letterSpacing: 'normal',
+    fontWeight: 'bold',
+  },
+  normal: {
+    fontFamily: 'body',
+    fontSize: 'normal',
+    lineHeight: '5',
+    letterSpacing: 'wide',
+    fontWeight: 'normal',
+  },
+  small: {
+    fontFamily: 'body',
+    fontSize: 'small',
+    lineHeight: '4',
+    letterSpacing: 'wide',
+    fontWeight: 'medium',
+  },
+  xsmall: {
+    fontFamily: 'body',
+    fontSize: 'xsmall',
+    lineHeight: '4',
+    letterSpacing: 'wide',
+    fontWeight: 'bold',
+  },
+  code: {
+    fontFamily: 'mono',
+    fontSize: 'normal',
+    lineHeight: '5',
+    letterSpacing: 'none',
+    fontWeight: 'normal',
+  },
+}


### PR DESCRIPTION
This allows for overriding variant props like fontWeight.

A useful pattern we might want to use in other places