### PR TITLE
Add video mime type support for file inputs

### DIFF
--- a/src/components/FileInput/FileInput.tsx
+++ b/src/components/FileInput/FileInput.tsx
@@ -19,8 +19,9 @@ const MIME_TYPES = {
   png: '.png,image/png',
   jpeg: '.jpeg,image/jpeg',
   jpg: '.jpg,image/jpg',
-  images: 'image/*',
+  images: 'image/*, video/*',
   pdf: '.pdf,application/pdf',
+  mp4: '.mp4,video/mp4',
 }
 
 type AllowedMimeTypes = keyof typeof MIME_TYPES


### PR DESCRIPTION
Adding support for video files in file input component. This will be used to add video banners in marketplace collections.