### PR TITLE
PINCodeInput: Fixes paste on Firefox

### DIFF
--- a/src/components/PINCodeInput/PINCodeInput.tsx
+++ b/src/components/PINCodeInput/PINCodeInput.tsx
@@ -39,6 +39,7 @@ export const PINCodeInput = (props: PINCodeInputProps) => {
     const curr = [...value]
     curr[idx] = character
 
+    // Don't advance the cursor if the character is empty
     if (character !== '') {
       inputRefs[idx + 1]?.current?.focus()
     }
@@ -98,6 +99,8 @@ export const PINCodeInput = (props: PINCodeInputProps) => {
     idx: number,
     ev: React.ClipboardEvent<HTMLInputElement>
   ) => {
+    ev.preventDefault()
+
     const pasted = ev.clipboardData.getData('text/plain')
     const filtered = pasted.replace(/\D/g, '')
     const re = new RegExp(`^\\d{${digits}}$`)


### PR DESCRIPTION
onPaste and onChange were conflicting which each other on Firefox. When a paste occurred the onChange event would fire and override the value set by the paste due to the order of the events. On Chrome the onChange event didn't occur because the prop change happens before the onChange event. Since we are using a controlled input setting the value via props the fix was to simply preventDefault on paste and update the value prop.