### PR TITLE
Set default text color to primary

### DIFF
--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -146,7 +146,7 @@ export const Text = (props: TextProps) => {
   const {
     asChild,
     variant = 'inherit',
-    color,
+    color = 'primary',
     fontWeight,
     className,
     hidden,


### PR DESCRIPTION
When there is no default text color, the text color defaults to black in dark mode if no color is specified. It might be better to use primary as the default.