### PR TITLE
Update slottable conditional for buttons

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -192,24 +192,28 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         type={type}
         {...rest}
       >
-        <Slottable>{children}</Slottable>
-
-        {iconOnly ? (
-          <LeftIcon size={iconSize} />
+        {children ? (
+          <Slottable>{children}</Slottable>
         ) : (
-          <div
-            className={cn(
-              'w-full h-full flex items-center justify-between',
-              gap
-            )}
-          >
-            <div className={cn('flex items-center justify-start', gap)}>
-              {LeftIcon && <LeftIcon size={iconSize} />}
-              <Text>{label}</Text>
-            </div>
+          <>
+            {iconOnly ? (
+              <LeftIcon size={iconSize} />
+            ) : (
+              <div
+                className={cn(
+                  'w-full h-full flex items-center justify-between',
+                  gap
+                )}
+              >
+                <div className={cn('flex items-center justify-start', gap)}>
+                  {LeftIcon && <LeftIcon size={iconSize} />}
+                  <Text>{label}</Text>
+                </div>
 
-            {RightIcon && <RightIcon size={iconSize} />}
-          </div>
+                {RightIcon && <RightIcon size={iconSize} />}
+              </div>
+            )}
+          </>
         )}
       </Component>
     )


### PR DESCRIPTION
When using children (slottable), the icon & label contains remain, creating a button that has some hidden elements on the right side.

This condition checks if there are children, then uses a slottable when there is, and the default label & icon config if not.

### before

<img width="1139" alt="CleanShot 2025-03-04 at 11 29 09@2x" src="https://github.com/user-attachments/assets/289a8969-904e-485a-a50b-a819af818944" />

### after 
![CleanShot 2025-03-04 at 11 33 00@2x](https://github.com/user-attachments/assets/551adc59-f499-4c00-bb9e-a45ed7456802)

I'm not sure if there are any knock-on effects of hiding the label & icons when children is used, but it appears that that any label and icons would always show up on the right side of the children if both children and icons/label are used
