### PR TITLE
Switch to @theme inline to fix css var to var referencing issues

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -16,6 +16,6 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-text-smoothing: grayscale;
 
-    background: var(--color-background-primary);
+    background: var(--seq-color-background-primary);
   }
 </style>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -8,11 +8,12 @@ import docsTheme from './theme'
 import './index.css'
 
 const CUSTOM_THEME = {
-  primary: 'rgba(255, 255, 255, 1)',
-  secondary: 'rgba(200, 200, 255, 1)',
-  muted: 'rgba(150, 150, 200, 1)',
-  backgroundPrimary: 'pink',
-  backgroundSecondary: 'navy',
+  primary: '#002C54',
+  secondary: '#396E97',
+  muted: '#71A6B2',
+  backgroundPrimary: '#F1F1F2',
+  backgroundSecondary: '#A1D6E2',
+  gradientPrimary: 'linear-gradient(45deg, #1995AD 0%, #002C54 100%)',
 }
 
 const withTheme: Decorator = (StoryFn, context) => {

--- a/src/components/ThemeProvider/ThemeProvider.stories.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.stories.tsx
@@ -22,6 +22,15 @@ export const Default = () => {
   return <Button label="Toggle theme" onClick={toggleTheme} />
 }
 
+const customTheme = {
+  primary: '#002C54',
+  secondary: '#396E97',
+  muted: '#71A6B2',
+  backgroundPrimary: '#F1F1F2',
+  backgroundSecondary: '#A1D6E2',
+  gradientPrimary: 'linear-gradient(45deg, #1995AD 0%, #002C54 100%)',
+}
+
 export const Nested = () => {
   return (
     <Card>
@@ -32,7 +41,7 @@ export const Nested = () => {
       <div id="app1">
         <ThemeProvider root="#app1" scope="application1" theme="light">
           <Card className="bg-background-primary mt-4">
-            <Collapsible label="Nested Application 1">
+            <Collapsible label="Nested Application 1" defaultOpen>
               <Text variant="normal" color="primary">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
                 eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
@@ -50,7 +59,10 @@ export const Nested = () => {
               <div id="app2">
                 <ThemeProvider root="#app2" scope="application2" theme="dark">
                   <Card className="bg-background-primary mt-4">
-                    <Collapsible label="Nested Application 2 (Dark)">
+                    <Collapsible
+                      label="Nested Application 2 (Dark)"
+                      defaultOpen
+                    >
                       <Text variant="normal" color="primary">
                         Lorem ipsum dolor sit amet, consectetur adipiscing elit,
                         sed do eiusmod tempor incididunt ut labore et dolore
@@ -75,16 +87,13 @@ export const Nested = () => {
                 <ThemeProvider
                   root="#app3"
                   scope="application3"
-                  theme={{
-                    primary: 'rgba(255, 255, 255, 1)',
-                    secondary: 'rgba(200, 200, 255, 1)',
-                    muted: 'rgba(150, 150, 200, 1)',
-                    backgroundPrimary: 'pink',
-                    backgroundSecondary: 'navy',
-                  }}
+                  theme={customTheme}
                 >
                   <Card className="bg-background-primary mt-4">
-                    <Collapsible label="Nested Application 3 (Custom Theme)">
+                    <Collapsible
+                      label="Nested Application 3 (Custom Theme)"
+                      defaultOpen
+                    >
                       <Text variant="normal" color="primary">
                         Lorem ipsum dolor sit amet, consectetur adipiscing elit,
                         sed do eiusmod tempor incididunt ut labore et dolore
@@ -96,6 +105,11 @@ export const Nested = () => {
                         non proident, sunt in culpa qui officia deserunt mollit
                         anim id est laborum.
                       </Text>
+
+                      <div className="mt-4 flex gap-2">
+                        <SetThemeButton />
+                        <SetCustomThemeButton />
+                      </div>
                     </Collapsible>
                   </Card>
                 </ThemeProvider>
@@ -108,7 +122,10 @@ export const Nested = () => {
                   prefersColorScheme
                 >
                   <Card className="bg-background-primary mt-4">
-                    <Collapsible label="Nested Application 4 (Prefers Color Scheme)">
+                    <Collapsible
+                      label="Nested Application 4 (Prefers Color Scheme)"
+                      defaultOpen
+                    >
                       <Text variant="normal" color="primary">
                         Lorem ipsum dolor sit amet, consectetur adipiscing elit,
                         sed do eiusmod tempor incididunt ut labore et dolore
@@ -120,6 +137,10 @@ export const Nested = () => {
                         non proident, sunt in culpa qui officia deserunt mollit
                         anim id est laborum.
                       </Text>
+
+                      <div className="mt-4">
+                        <Button variant="primary" label="Click me" />
+                      </div>
                     </Collapsible>
                   </Card>
                 </ThemeProvider>
@@ -141,5 +162,21 @@ const SetThemeButton = () => {
     setTheme(theme === 'light' ? 'dark' : 'light')
   }
 
-  return <Button label={`Set ${themeLabel} Mode`} onClick={toggleTheme} />
+  return (
+    <Button
+      variant="primary"
+      label={`Set ${themeLabel} Mode`}
+      onClick={toggleTheme}
+    />
+  )
+}
+
+const SetCustomThemeButton = () => {
+  const { setTheme } = useTheme()
+
+  const toggleTheme = () => {
+    setTheme(customTheme)
+  }
+
+  return <Button label="Set Custom Mode" onClick={toggleTheme} />
 }

--- a/src/components/ThemeProvider/ThemeProvider.stories.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.stories.tsx
@@ -137,10 +137,6 @@ export const Nested = () => {
                         non proident, sunt in culpa qui officia deserunt mollit
                         anim id est laborum.
                       </Text>
-
-                      <div className="mt-4">
-                        <Button variant="primary" label="Click me" />
-                      </div>
                     </Collapsible>
                   </Card>
                 </ThemeProvider>

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -52,7 +52,7 @@ const setThemeVars = (element: HTMLElement, vars: ThemeOverrides) => {
   Object.entries(vars).forEach(([key, value]) => {
     if (value) {
       const kebabKey = toKebabCase(key)
-      element.style.setProperty(`--color-${kebabKey}`, value)
+      element.style.setProperty(`--seq-color-${kebabKey}`, value)
     }
   })
 }

--- a/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.tsx
@@ -47,12 +47,24 @@ const getStorageKey = (scope?: string) =>
 const toKebabCase = (str: string) =>
   str.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
 
+const toCSSVar = (key: string) => `--seq-color-${toKebabCase(key)}`
+
+const colorVars = (Object.keys(colors.dark) as string[]).map(key =>
+  toCSSVar(key)
+)
+
+const clearThemeVars = (element: HTMLElement) => {
+  // Clear each color token CSS variable
+  colorVars.forEach(colorVar => {
+    element.style.removeProperty(colorVar)
+  })
+}
+
 const setThemeVars = (element: HTMLElement, vars: ThemeOverrides) => {
   // Set each color token as a CSS variable
   Object.entries(vars).forEach(([key, value]) => {
     if (value) {
-      const kebabKey = toKebabCase(key)
-      element.style.setProperty(`--seq-color-${kebabKey}`, value)
+      element.style.setProperty(toCSSVar(key), value)
     }
   })
 }
@@ -114,9 +126,12 @@ export const ThemeProvider = (props: PropsWithChildren<ThemeProviderProps>) => {
         : (document.querySelector(props.root || ':root') as HTMLElement)
 
     if (rootElement) {
+      clearThemeVars(rootElement)
+
       if (isColorScheme(theme)) {
         rootElement.setAttribute(THEME_ATTR, theme)
-        setThemeVars(rootElement, colors[theme])
+        // XXX: We don't need to set the theme vars here because its already defined in the CSS
+        // setThemeVars(rootElement, colors[theme])
       } else if (isThemeOverrides(theme)) {
         rootElement.setAttribute(THEME_ATTR, 'custom')
         setThemeVars(rootElement, theme)

--- a/src/docs/design-system/Colors.mdx
+++ b/src/docs/design-system/Colors.mdx
@@ -13,7 +13,7 @@ Color schemes, scales, accents, and gradients.
 <ColorPalette>
   <ColorItem
     title="Base"
-    subtitle="--color-[name]"
+    subtitle="--seq-color-[name]"
     colors={{
       black: '#000000',
       white: '#ffffff',
@@ -30,7 +30,7 @@ Semantic colors point to color palettes and are used to give a name to a color t
     <ColorItem
       key={key}
       title={key}
-      subtitle={`--color-${key}`}
+      subtitle={`--seq-color-${key}`}
       colors={{ [key]: value }}
     />
   ))}

--- a/src/index.css
+++ b/src/index.css
@@ -1,105 +1,127 @@
 @source './';
 
-@layer base {
-  .seq-root *,
-  .seq-root *::before,
-  .seq-root *::after {
-    box-sizing: border-box;
-  }
+:root,
+[data-theme='dark'] {
+  /* Status colors */
+  --seq-color-positive: #1fc266;
+  --seq-color-negative: #c2501f;
+  --seq-color-info: #0076cc;
+  --seq-color-warning: #f4b03e;
 
-  :root,
-  [data-theme='dark'] {
-    /* Status colors */
-    --seq-color-positive: #1fc266;
-    --seq-color-negative: #c2501f;
-    --seq-color-info: #0076cc;
-    --seq-color-warning: #f4b03e;
+  /* Text colors */
+  --seq-color-primary: rgba(255, 255, 255, 1);
+  --seq-color-secondary: rgba(255, 255, 255, 0.8);
+  --seq-color-muted: rgba(255, 255, 255, 0.5);
+  --seq-color-inverse: rgba(0, 0, 0, 1);
 
-    /* Text colors */
-    --seq-color-primary: rgba(255, 255, 255, 1);
-    --seq-color-secondary: rgba(255, 255, 255, 0.8);
-    --seq-color-muted: rgba(255, 255, 255, 0.5);
-    --seq-color-inverse: rgba(0, 0, 0, 1);
+  /* Background colors */
+  --seq-color-background-primary: rgba(0, 0, 0, 1);
+  --seq-color-background-secondary: rgba(255, 255, 255, 0.1);
+  --seq-color-background-contrast: rgba(255, 255, 255, 0.5);
+  --seq-color-background-muted: rgba(255, 255, 255, 0.05);
+  --seq-color-background-control: rgba(255, 255, 255, 0.25);
+  --seq-color-background-inverse: rgba(255, 255, 255, 1);
+  --seq-color-background-backdrop: rgba(34, 34, 34, 0.9);
+  --seq-color-background-overlay: rgba(0, 0, 0, 0.7);
+  --seq-color-background-raised: rgba(54, 54, 54, 0.7);
 
-    /* Background colors */
-    --seq-color-background-primary: rgba(0, 0, 0, 1);
-    --seq-color-background-secondary: rgba(255, 255, 255, 0.1);
-    --seq-color-background-contrast: rgba(255, 255, 255, 0.5);
-    --seq-color-background-muted: rgba(255, 255, 255, 0.05);
-    --seq-color-background-control: rgba(255, 255, 255, 0.25);
-    --seq-color-background-inverse: rgba(255, 255, 255, 1);
-    --seq-color-background-backdrop: rgba(34, 34, 34, 0.9);
-    --seq-color-background-overlay: rgba(0, 0, 0, 0.7);
-    --seq-color-background-raised: rgba(54, 54, 54, 0.7);
+  /* Border colors */
+  --seq-color-border-normal: rgba(255, 255, 255, 0.25);
+  --seq-color-border-focus: rgba(255, 255, 255, 0.5);
 
-    /* Border colors */
-    --seq-color-border-normal: rgba(255, 255, 255, 0.25);
-    --seq-color-border-focus: rgba(255, 255, 255, 0.5);
+  /* Button colors */
+  --seq-color-button-glass: rgba(255, 255, 255, 0.15);
+  --seq-color-button-emphasis: rgba(0, 0, 0, 0.5);
+  --seq-color-button-inverse: rgba(255, 255, 255, 0.8);
 
-    /* Button colors */
-    --seq-color-button-glass: rgba(255, 255, 255, 0.15);
-    --seq-color-button-emphasis: rgba(0, 0, 0, 0.5);
-    --seq-color-button-inverse: rgba(255, 255, 255, 0.8);
-
-    /* Gradients */
-    --seq-color-gradient-backdrop: linear-gradient(
-      243.18deg,
-      rgba(86, 52, 189, 0.85) 0%,
-      rgba(49, 41, 223, 0.85) 63.54%,
-      rgba(7, 98, 149, 0.85) 100%
-    );
-    --seq-color-gradient-primary: linear-gradient(
-      89.69deg,
-      #4411e1 0.27%,
-      #7537f9 99.73%
-    );
-
-    --seq-color-gradient-secondary: linear-gradient(
-      32.51deg,
-      #951990 -15.23%,
-      #3a35b1 48.55%,
-      #20a8b0 100%
-    );
-
-    --seq-color-gradient-skeleton: linear-gradient(
-      -45deg,
-      transparent,
-      var(--seq-color-background-secondary),
-      transparent
-    );
-  }
-
-  [data-theme='light'] {
-    /* Text colors */
-    --seq-color-primary: rgba(0, 0, 0, 1);
-    --seq-color-secondary: rgba(0, 0, 0, 0.8);
-    --seq-color-muted: rgba(0, 0, 0, 0.5);
-    --seq-color-inverse: rgba(255, 255, 255, 1);
-
-    /* Background colors */
-    --seq-color-background-primary: rgba(244, 244, 244, 1);
-    --seq-color-background-secondary: rgba(0, 0, 0, 0.1);
-    --seq-color-background-contrast: rgba(244, 244, 244, 0.5);
-    --seq-color-background-muted: rgba(0, 0, 0, 0.05);
-    --seq-color-background-control: rgba(0, 0, 0, 0.25);
-    --seq-color-background-inverse: #rgba(0, 0, 0, 1);
-    --seq-color-background-backdrop: rgba(221, 221, 221, 0.9);
-    --seq-color-background-overlay: rgba(244, 244, 244, 0.7);
-    --seq-color-background-raised: rgba(192, 192, 192, 0.7);
-
-    /* Border colors */
-    --seq-color-border-normal: rgba(0, 0, 0, 0.25);
-    --seq-color-border-focus: rgba(0, 0, 0, 0.5);
-
-    /* Button colors */
-    --seq-color-button-glass: rgba(0, 0, 0, 0.15);
-    --seq-color-button-emphasis: rgba(255, 255, 255, 0.5);
-    --seq-color-button-inverse: rgba(0, 0, 0, 0.8);
-  }
+  /* Gradients */
+  --seq-color-gradient-backdrop: linear-gradient(
+    243.18deg,
+    rgba(86, 52, 189, 0.85) 0%,
+    rgba(49, 41, 223, 0.85) 63.54%,
+    rgba(7, 98, 149, 0.85) 100%
+  );
+  --seq-color-gradient-primary: linear-gradient(
+    89.69deg,
+    #4411e1 0.27%,
+    #7537f9 99.73%
+  );
+  --seq-color-gradient-secondary: linear-gradient(
+    32.51deg,
+    #951990 -15.23%,
+    #3a35b1 48.55%,
+    #20a8b0 100%
+  );
+  --seq-color-gradient-skeleton: linear-gradient(
+    -45deg,
+    transparent,
+    var(--seq-color-background-secondary),
+    transparent
+  );
 }
 
-@theme {
-  --font-body: Inter, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+[data-theme='light'] {
+  /* Status colors */
+  --seq-color-positive: #1fc266;
+  --seq-color-negative: #c2501f;
+  --seq-color-info: #0076cc;
+  --seq-color-warning: #f4b03e;
+
+  /* Text colors */
+  --seq-color-primary: rgba(0, 0, 0, 1);
+  --seq-color-secondary: rgba(0, 0, 0, 0.8);
+  --seq-color-muted: rgba(0, 0, 0, 0.5);
+  --seq-color-inverse: rgba(255, 255, 255, 1);
+
+  /* Background colors */
+  --seq-color-background-primary: rgba(244, 244, 244, 1);
+  --seq-color-background-secondary: rgba(0, 0, 0, 0.1);
+  --seq-color-background-contrast: rgba(244, 244, 244, 0.5);
+  --seq-color-background-muted: rgba(0, 0, 0, 0.05);
+  --seq-color-background-control: rgba(0, 0, 0, 0.25);
+  --seq-color-background-inverse: #rgba(0, 0, 0, 1);
+  --seq-color-background-backdrop: rgba(221, 221, 221, 0.9);
+  --seq-color-background-overlay: rgba(244, 244, 244, 0.7);
+  --seq-color-background-raised: rgba(192, 192, 192, 0.7);
+
+  /* Border colors */
+  --seq-color-border-normal: rgba(0, 0, 0, 0.25);
+  --seq-color-border-focus: rgba(0, 0, 0, 0.5);
+
+  /* Button colors */
+  --seq-color-button-glass: rgba(0, 0, 0, 0.15);
+  --seq-color-button-emphasis: rgba(255, 255, 255, 0.5);
+  --seq-color-button-inverse: rgba(0, 0, 0, 0.8);
+
+  /* Gradients */
+  --seq-color-gradient-backdrop: linear-gradient(
+    243.18deg,
+    rgba(86, 52, 189, 0.85) 0%,
+    rgba(49, 41, 223, 0.85) 63.54%,
+    rgba(7, 98, 149, 0.85) 100%
+  );
+  --seq-color-gradient-primary: linear-gradient(
+    89.69deg,
+    #4411e1 0.27%,
+    #7537f9 99.73%
+  );
+  --seq-color-gradient-secondary: linear-gradient(
+    32.51deg,
+    #951990 -15.23%,
+    #3a35b1 48.55%,
+    #20a8b0 100%
+  );
+  --seq-color-gradient-skeleton: linear-gradient(
+    -45deg,
+    transparent,
+    var(--seq-color-background-secondary),
+    transparent
+  );
+}
+
+@theme inline {
+  --font-body:
+    Inter, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
     'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 
   --color-primary: var(--seq-color-primary);

--- a/src/tokens/color.ts
+++ b/src/tokens/color.ts
@@ -41,6 +41,7 @@ export interface ColorTokens {
   gradientBackdrop: string
   gradientPrimary: string
   gradientSecondary: string
+  gradientSkeleton: string
 }
 
 const defaultColors = {
@@ -57,6 +58,7 @@ const defaultColors = {
   )`,
   gradientPrimary: `linear-gradient(89.69deg, #4411E1 0.27%, #7537F9 99.73%)`,
   gradientSecondary: `linear-gradient(32.51deg, #951990 -15.23%, #3A35B1 48.55%, #20A8B0 100%)`,
+  gradientSkeleton: `linear-gradient(-45deg, transparent, var(--seq-color-background-secondary), transparent)`,
 }
 
 const dark: ColorTokens = {


### PR DESCRIPTION
Using inline theme mode is a way for tailwind to configure utility classes for the theme but points to the inline values, `--seq-color-*` vars in this case, rather than creating new variables.

When a css variable references another css variable, changing the referenced variables at difference levels in the dom will have no effect.