### PR TITLE
feat(Card): hover state for clickable cards

### DIFF
--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -101,3 +101,30 @@ export const Clickable: Story = {
     onClick: () => console.log('Clicked!'),
   },
 }
+
+export const ClickableHover: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Hover a clickable card to surface the `border-hover` color swap.',
+      },
+    },
+  },
+  render: args => (
+    <div className="flex flex-col gap-4">
+      {(['default', 'outline', 'muted'] as const).map(variant => (
+        <Card key={variant} {...args} variant={variant} render={<button />}>
+          <CardHeader>
+            <CardTitle className="capitalize">{variant}</CardTitle>
+            <CardDescription>Hover me</CardDescription>
+          </CardHeader>
+        </Card>
+      ))}
+    </div>
+  ),
+  args: {
+    clickable: true,
+    onClick: () => console.log('Clicked!'),
+  },
+}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -15,7 +15,10 @@ export const cardVariants = cva(
         muted: 'bg-background-muted border-1 border-border-card',
       },
       clickable: {
-        true: ['cursor-pointer hover:opacity-80', focusRingVariants()],
+        true: [
+          'cursor-pointer hover:border-transparent hover:outline-2 hover:outline-border-hover hover:outline-offset-0',
+          focusRingVariants(),
+        ],
       },
       disabled: {
         true: 'opacity-50 cursor-default pointer-events-none hover:border-border-card',

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -16,7 +16,7 @@ export const cardVariants = cva(
       },
       clickable: {
         true: [
-          'cursor-pointer hover:border-transparent hover:outline-2 hover:outline-border-hover hover:outline-offset-0',
+          'cursor-pointer hover:border-transparent hover:ring-2 hover:ring-border-hover',
           focusRingVariants(),
         ],
       },


### PR DESCRIPTION
## Summary
- Replaced the `hover:opacity-80` affordance on `clickable` cards with a 2px outline in `border-hover`
- On hover, the underlying 1px border becomes `transparent` so the outline reads as a single edge (not a layered shadow under the border)
- Added a `ClickableHover` story covering all three variants

## Why outline instead of a thicker border?
A `border-1` → `border-2` swap on hover causes a 1px layout shift on every hover/leave because the border participates in the box model. `outline` lives outside the box model, so swapping `outline-2` on/off doesn't reflow content. `outline-offset-0` keeps it tight to the edge so it reads as a border thickening, and modern browsers follow `border-radius` on outlines automatically.

`border-transparent` on hover hides the 1px card border underneath the new outline — without it, the 1px border + 2px outline stack visually like a faint shadow.

## Trade-off
When a card is both `:hover` and `:focus-visible`, `hover:outline-offset-0` overrides `focusRingVariants`' `outline-offset-2`, so the focus ring snaps tight on hover. Acceptable for now; if it ever bothers us we can swap the hover affordance to `ring` (box-shadow) so the two states use different properties.


https://github.com/user-attachments/assets/0c1dec46-241a-46d1-abd9-5641d8be0a79